### PR TITLE
bloggify-actions 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ The actions' handlers should return promises.
 Have an idea? Found a bug? See [how to contribute][contributing].
 
 
+## :dizzy: Where is this library used?
+If you are using this library in one of your projects, add it in this list. :sparkles:
+
+
+ - [`bloggify`](https://github.com/Bloggify/Bloggify) (by Bloggify)—We make publishing easy.
 
 ## :scroll: License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,8 +38,12 @@ module.exports = () => {
             const actionName = `${groupName}.${name}`;
             let method = /insert|update|remove|delete/i.test(name) ? "post" : "get"
 
-            if (typeof action === "object") {
+            if (Array.isArray(action)) {
+                method = action[0]
+                action = action[1]
+            } else if (typeof action === "object") {
                 method = action.method || method
+                action = action.action
             }
 
             if (group.before) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "core"
   ],
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/index.js",
   "author": "Bloggify <support@bloggify.org> (https://bloggify.org)",
   "homepage": "https://github.com/Bloggify/bloggify-actions#readme",


### PR DESCRIPTION
Allow arrays as actions

exports.foo = ["post", ctx => ... ]
